### PR TITLE
feat(knowledge): 列表页 + 独立详情页 + Markdown 渲染

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Monorepo for a personal AI-managed life notebook.
 - `backend/`: API and AI gateway
 - `docs/`: Planning docs
 
+## Collaboration
+- Branch workflow: `docs/git-workflow.md`
+- Development model: GitHub Issue -> `feature/*` -> PR to `dev` -> review -> merge
+
 ## Quick Start
 
 ### Backend (uv)

--- a/backend/app/api/routes_knowledge.py
+++ b/backend/app/api/routes_knowledge.py
@@ -70,6 +70,15 @@ def create_entry(payload: EntryCreate) -> EntryOut:
     return entry
 
 
+@router.get("/{entry_id}", response_model=EntryOut)
+def get_entry(entry_id: int) -> EntryOut:
+    entries = _load_entries()
+    entry = next((row for row in entries if row.id == entry_id), None)
+    if not entry:
+        raise HTTPException(status_code=404, detail="entry not found")
+    return entry
+
+
 @router.delete("/{entry_id}")
 def delete_entry(entry_id: int) -> dict[str, int | bool]:
     entries = _load_entries()

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,0 +1,56 @@
+# Git Branch Workflow
+
+This repository follows `main -> dev -> feature/*`.
+
+## Branch Roles
+- `main`: production/stable code only.
+- `dev`: integration branch for reviewed feature work.
+- `feature/<name>`: isolated development branch for one feature/fix.
+
+## Required Flow
+1. Create feature branch from `dev`.
+2. Develop and commit on `feature/<name>`.
+3. Push feature branch and open PR to `dev`.
+4. After review and merge into `dev`, run integration testing on `dev`.
+5. When ready for release, open PR from `dev` to `main`.
+
+## Issue-Driven Workflow
+1. Create (or select) a GitHub Issue for the task.
+2. Apply labels (at minimum one `priority:*` label and one type label such as `feat`/`bug`).
+3. Create branch from `dev` using issue ID:
+   - `feature/<issue-id>-<short-name>`
+4. Implement changes in that feature branch only.
+5. Open PR from feature branch to `dev` and link the issue (`Closes #<id>` in PR body).
+6. Wait for maintainer review and merge approval.
+7. Promote `dev -> main` only after validation/testing.
+
+## Command Examples
+```bash
+# update local branches
+git checkout dev
+git pull origin dev
+
+# create feature branch
+git checkout -b feature/knowledge-markdown-preview
+
+# after development
+git add .
+git commit -m "feat: improve markdown preview for knowledge pages"
+git push -u origin feature/knowledge-markdown-preview
+```
+
+## Pull Request Rules
+- Feature PR target branch must be `dev`.
+- Do not push unfinished feature work directly to `dev` or `main`.
+- `main` only accepts tested changes from `dev`.
+- Every feature/fix should map to a GitHub Issue.
+- PR description should include: scope, risk, test result, and linked issue.
+
+## Codex Execution Policy
+- Codex should work by: create/update issue -> create `feature/*` branch -> implement -> push -> open PR to `dev`.
+- Codex does not merge PRs to `dev` or `main` without maintainer approval.
+- Maintainer reviews PR first; merge is manual after approval.
+
+## CI/CD (Planned)
+- Add CI on PR to `dev`: lint + tests + build.
+- Add release workflow on merge `dev -> main`.

--- a/frontend/app/knowledge/blog/[id]/page.tsx
+++ b/frontend/app/knowledge/blog/[id]/page.tsx
@@ -1,0 +1,13 @@
+import { KnowledgeDetail } from "@/components/KnowledgeDetail";
+import { TopNav } from "@/components/TopNav";
+
+export default function KnowledgeBlogDetailPage({ params }: { params: { id: string } }) {
+  const entryId = Number(params.id);
+
+  return (
+    <main className="page-shell">
+      <TopNav />
+      <KnowledgeDetail entryId={entryId} expectedKind="blog" />
+    </main>
+  );
+}

--- a/frontend/app/knowledge/entry/[id]/page.tsx
+++ b/frontend/app/knowledge/entry/[id]/page.tsx
@@ -1,0 +1,13 @@
+import { KnowledgeDetail } from "@/components/KnowledgeDetail";
+import { TopNav } from "@/components/TopNav";
+
+export default function KnowledgeEntryDetailPage({ params }: { params: { id: string } }) {
+  const entryId = Number(params.id);
+
+  return (
+    <main className="page-shell">
+      <TopNav />
+      <KnowledgeDetail entryId={entryId} expectedKind="entry" />
+    </main>
+  );
+}

--- a/frontend/components/KnowledgeDetail.tsx
+++ b/frontend/components/KnowledgeDetail.tsx
@@ -1,0 +1,78 @@
+﻿"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+import { getKnowledgeEntryById, type KnowledgeEntry } from "@/lib/api";
+import { markdownToHtml } from "@/lib/markdown";
+
+function formatTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
+}
+
+export function KnowledgeDetail({ entryId, expectedKind }: { entryId: number; expectedKind: "blog" | "entry" }) {
+  const [entry, setEntry] = useState<KnowledgeEntry | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const data = await getKnowledgeEntryById(entryId);
+        if (data.kind !== expectedKind) {
+          setError(`该条目不是${expectedKind === "entry" ? "词条" : "博客"}类型`);
+          setEntry(null);
+        } else {
+          setEntry(data);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "读取详情失败");
+        setEntry(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (!Number.isFinite(entryId) || entryId <= 0) {
+      setError("无效的条目 ID");
+      setLoading(false);
+      return;
+    }
+
+    void load();
+  }, [entryId, expectedKind]);
+
+  const html = useMemo(() => markdownToHtml(entry?.markdown ?? ""), [entry?.markdown]);
+
+  if (loading) {
+    return <section className="panel placeholder-page">加载中...</section>;
+  }
+
+  if (error || !entry) {
+    return (
+      <section className="panel placeholder-page">
+        <p>{error || "未找到条目"}</p>
+        <Link className="entry-link" href={expectedKind === "entry" ? "/knowledge/entry" : "/knowledge/blog"}>
+          返回列表
+        </Link>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel placeholder-page">
+      <div className="feed-meta">
+        {entry.kind === "entry" ? "词条" : "博客"} · {formatTime(entry.updated_at)}
+      </div>
+      <h1>{entry.title}</h1>
+      <div className="markdown-render" dangerouslySetInnerHTML={{ __html: html }} />
+      <Link className="entry-link" href={expectedKind === "entry" ? "/knowledge/entry" : "/knowledge/blog"}>
+        返回列表
+      </Link>
+    </section>
+  );
+}

--- a/frontend/components/KnowledgeWorkspace.tsx
+++ b/frontend/components/KnowledgeWorkspace.tsx
@@ -1,6 +1,7 @@
 ﻿"use client";
 
 import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 
 import { createKnowledgeEntry, deleteKnowledgeEntry, getKnowledgeEntries, type KnowledgeEntry } from "@/lib/api";
 import { markdownToHtml } from "@/lib/markdown";
@@ -120,7 +121,11 @@ export function KnowledgeWorkspace({ kind, title, description }: { kind: Kind; t
           <article className="feed-item" key={entry.id}>
             <div className="feed-meta">{formatTime(entry.updated_at)}</div>
             <div>{entry.title}</div>
-            <div className="markdown-render" dangerouslySetInnerHTML={{ __html: markdownToHtml(entry.markdown) }} />
+            <div className="feed-meta">#{entry.id}</div>
+            <div className="markdown-render" dangerouslySetInnerHTML={{ __html: markdownToHtml(entry.markdown.slice(0, 180)) }} />
+            <Link className="entry-link" href={`/knowledge/${kind}/${entry.id}`}>
+              查看详情页
+            </Link>
             <button className="pill danger" type="button" onClick={() => void handleDelete(entry.id)}>
               删除
             </button>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -224,6 +224,10 @@ export async function getKnowledgeEntries(params?: { kind?: string; q?: string }
   return apiRequest<KnowledgeEntry[]>(`/knowledge/${suffix}`);
 }
 
+export async function getKnowledgeEntryById(entryId: number): Promise<KnowledgeEntry> {
+  return apiRequest<KnowledgeEntry>(`/knowledge/${entryId}`);
+}
+
 export async function createKnowledgeEntry(payload: {
   kind: "blog" | "entry";
   title: string;


### PR DESCRIPTION
## 变更内容
- 词条与博客保留列表页
- 新增独立详情页路由：
  - /knowledge/entry/[id]
  - /knowledge/blog/[id]
- 列表项新增“查看详情页”跳转
- 新增前端 Markdown 渲染组件用于预览与详情展示
- 后端新增单条查询接口：GET /knowledge/{entry_id}

## 关联 Issue
Closes #1

## 风险与影响
- 主要影响知识库模块路由与展示
- 其他模块不受影响

## 测试
- 本地路由与组件静态检查
- 后端路由导入检查通过