### PR TITLE
docs: clarify api reference and collaboration process

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Monorepo for a personal AI-managed life notebook.
 ## Collaboration
 - Branch workflow: `docs/git-workflow.md`
 - Development model: GitHub Issue -> `feature/*` -> PR to `dev` -> review -> merge
+- API reference: `docs/api-reference.md`
 
 ## Quick Start
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,6 +9,7 @@ uv run uvicorn app.main:app --reload
 ## API Overview
 - `GET /health/`: health check
 - `POST /ai/chat`: AI gateway entry
+- `POST /ai/parse-record`: parse natural language into structured suggestion
 - `GET/POST /tasks/`: task list/create
 - `DELETE /tasks/{id}`: delete task
 - `GET/POST /assets/transactions`: wallet transaction list/create
@@ -22,9 +23,13 @@ uv run uvicorn app.main:app --reload
 - `GET/POST /feed/`: activity feed
 - `DELETE /feed/{id}`: delete activity
 - `GET/POST /knowledge/`: knowledge entries
+- `GET /knowledge/{id}`: knowledge entry detail
 - `DELETE /knowledge/{id}`: delete entry
 - `GET/PUT /settings/`: app settings
 
 ## Persistence
 - Data is persisted as JSON files in `backend/data/`.
 - Current files: `tasks.json`, `feed.json`, `knowledge.json`, `assets.json`, `settings.json`.
+
+## Reference
+- Full API reference: `docs/api-reference.md`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,69 @@
+# API Reference
+
+Base URL (local): `http://localhost:8000`
+
+## Health
+- `GET /health/`
+  - Response: `{ "status": "ok" }`
+
+## AI
+- `POST /ai/chat`
+  - Body: `{ "provider": "codex|openai-compatible|ollama", "session_id": "...", "prompt": "..." }`
+- `POST /ai/parse-record`
+  - Body: `{ "text": "..." }`
+  - Response includes detected type/category and extracted fields.
+
+## Tasks
+- `GET /tasks/`
+- `POST /tasks/`
+  - Body: `{ "title", "category", "importance", "start_at", "end_at" }`
+- `DELETE /tasks/{task_id}`
+
+## Feed (Activity)
+- `GET /feed/`
+- `POST /feed/`
+  - Body: `{ "category", "content" }`
+- `DELETE /feed/{feed_id}`
+
+## Knowledge
+- `GET /knowledge/?kind=entry|blog&q=keyword`
+- `GET /knowledge/{entry_id}`
+- `POST /knowledge/`
+  - Body: `{ "kind": "entry|blog", "title", "markdown" }`
+- `DELETE /knowledge/{entry_id}`
+
+## Assets
+### Accounts
+- `GET /assets/accounts`
+
+### Transactions
+- `GET /assets/transactions?category=...&month=YYYY-MM`
+- `POST /assets/transactions`
+  - Body: `{ "account", "type": "income|expense", "category", "amount", "happened_on", "note" }`
+- `DELETE /assets/transactions/{transaction_id}`
+
+### Summary
+- `GET /assets/cash-total`
+- `GET /assets/category-summary?month=YYYY-MM`
+- `GET /assets/monthly-summary`
+
+### Investment Logs
+- `GET /assets/investment/logs`
+- `POST /assets/investment/logs`
+  - Body: `{ "happened_on", "invested", "daily_profit", "note" }`
+- `DELETE /assets/investment/logs/{log_id}`
+- `GET /assets/investment/trend`
+
+## Settings
+- `GET /settings/`
+- `PUT /settings/`
+  - Body: `{ "default_provider", "model_name", "theme", "local_only" }`
+
+## Persistence
+- Data files are persisted in `backend/data/`.
+- Current files:
+  - `backend/data/tasks.json`
+  - `backend/data/feed.json`
+  - `backend/data/knowledge.json`
+  - `backend/data/assets.json`
+  - `backend/data/settings.json`

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -51,6 +51,22 @@ git push -u origin feature/knowledge-markdown-preview
 - Codex does not merge PRs to `dev` or `main` without maintainer approval.
 - Maintainer reviews PR first; merge is manual after approval.
 
+## Docs-Only Exception Flow
+Use this flow only for documentation-only changes (no runtime code changes):
+1. Create a docs issue and label with `docs` (+ optional priority label).
+2. Branch from `dev` using issue id:
+   - `feature/<issue-id>-docs-<short-name>`
+3. Open PR to `dev` and link the issue (`Closes #<id>`).
+4. If maintainer explicitly allows self-merge for this docs task:
+   - merge the PR to `dev` by yourself,
+   - delete remote feature branch,
+   - delete local feature branch,
+   - confirm issue is closed.
+5. Return to `dev` and sync:
+   - `git checkout dev && git pull origin dev`
+
+Docs-only exception must not be used for frontend/backend/runtime behavior changes.
+
 ## CI/CD (Planned)
 - Add CI on PR to `dev`: lint + tests + build.
 - Add release workflow on merge `dev -> main`.


### PR DESCRIPTION
## 变更内容
- 新增统一接口文档：docs/api-reference.md
- README 增加 API 参考入口
- backend README 补齐新增接口与参考链接
- git workflow 增加 docs-only 例外流程（自审自合并条件与步骤）

## 关联 Issue
Closes #3

## 说明
这是文档专项修复，未改动运行时代码。