### PR TITLE
chore(ui): remove parenthetical helper text from labels

### DIFF
--- a/frontend/app/assets/page.tsx
+++ b/frontend/app/assets/page.tsx
@@ -232,7 +232,7 @@ export default function AssetsPage() {
           <h3>筛选</h3>
           <div className="task-form-row">
             <label>
-              月份（YYYY-MM）
+              月份
               <input className="quick-input" value={filterMonth} onChange={(e) => setFilterMonth(e.target.value)} placeholder="2026-02" />
             </label>
             <label>
@@ -260,7 +260,7 @@ export default function AssetsPage() {
             ))}
           </div>
 
-          <h3>分类收支（本月）</h3>
+          <h3>分类收支</h3>
           <div className="asset-bars">
             {categorySummary.map((row) => {
               const total = parseNumber(row.income) + parseNumber(row.expense);

--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -12,7 +12,7 @@ export default function KnowledgeHomePage() {
 
         <div className="knowledge-hub">
           <article className="feed-item">
-            <div className="feed-meta">词条（Wiki 风格）</div>
+            <div className="feed-meta">词条</div>
             <div>记录新概念、新硬件、新术语。</div>
             <Link className="entry-link" href="/knowledge/entry">
               进入词条页
@@ -20,7 +20,7 @@ export default function KnowledgeHomePage() {
           </article>
 
           <article className="feed-item">
-            <div className="feed-meta">博客（过程记录）</div>
+            <div className="feed-meta">博客</div>
             <div>记录问题排查、方案设计和复盘。</div>
             <Link className="entry-link" href="/knowledge/blog">
               进入博客页

--- a/frontend/app/tasks/page.tsx
+++ b/frontend/app/tasks/page.tsx
@@ -99,11 +99,11 @@ export default function TasksPage() {
       <TopNav />
       <section className="panel placeholder-page">
         <h1>任务栏</h1>
-        <p>新增任务后会自动进入首页周时间表（按开始/结束时间块对齐）。</p>
+        <p>新增任务后会自动进入首页周时间表。</p>
 
         <div className="task-form">
           <input className="quick-input" placeholder="任务标题" value={title} onChange={(e) => setTitle(e.target.value)} />
-          <input className="quick-input" placeholder="分类（例如 财产/学习/健康）" value={category} onChange={(e) => setCategory(e.target.value)} />
+          <input className="quick-input" placeholder="分类" value={category} onChange={(e) => setCategory(e.target.value)} />
 
           <div className="task-form-row">
             <label>

--- a/frontend/components/WeeklyTimeline.tsx
+++ b/frontend/components/WeeklyTimeline.tsx
@@ -162,7 +162,7 @@ export function WeeklyTimeline() {
 
   return (
     <section className="panel timeline-panel">
-      <p className="panel-title">一周时间表（按统一时间轴对齐）</p>
+      <p className="panel-title">一周时间表</p>
       {loading ? <p className="wealth-note">正在读取任务...</p> : null}
       <div className="timeline-board">
         <div className="time-axis">


### PR DESCRIPTION
## Summary
Remove parenthetical helper text from user-facing labels/titles.

## Changes
- 一周时间表（按统一时间轴对齐） -> 一周时间表
- 词条（Wiki 风格） -> 词条
- 博客（过程记录） -> 博客
- 新增任务后会自动进入首页周时间表（按开始/结束时间块对齐）。 -> 新增任务后会自动进入首页周时间表。
- 分类（例如 财产/学习/健康） -> 分类
- 月份（YYYY-MM） -> 月份
- 分类收支（本月） -> 分类收支

## Risk
Low. Text-only frontend changes.

## Validation
- searched rontend for （...） patterns and removed matching UI helper text.

Closes #7