### PR TITLE
release: promote dev to main (empty defaults)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Backend default URL: `http://localhost:8000`
 ```bash
 powershell -ExecutionPolicy Bypass -File scripts/init-data.ps1
 ```
+- Fresh installs start with empty records; wallet/investment accounts are pre-created with `0.00` balance.
 - Backup data (zip to `backup/`):
 ```bash
 powershell -ExecutionPolicy Bypass -File scripts/backup-data.ps1

--- a/backend/app/api/routes_assets.py
+++ b/backend/app/api/routes_assets.py
@@ -12,46 +12,12 @@ router = APIRouter(prefix="/assets", tags=["assets"])
 _ASSETS_FILE = "assets.json"
 _DEFAULT_STATE = {
     "accounts": [
-        {"name": "微信钱包", "is_cash": True, "balance": "5680.50"},
-        {"name": "支付宝钱包", "is_cash": True, "balance": "8120.00"},
-        {"name": "支付宝理财", "is_cash": False, "balance": "13200.00"},
+        {"name": "微信钱包", "is_cash": True, "balance": "0.00"},
+        {"name": "支付宝钱包", "is_cash": True, "balance": "0.00"},
+        {"name": "支付宝理财", "is_cash": False, "balance": "0.00"},
     ],
-    "transactions": [
-        {
-            "id": 1,
-            "account": "微信钱包",
-            "type": "expense",
-            "category": "吃饭",
-            "amount": "32.00",
-            "happened_on": "2026-02-07",
-            "note": "午饭",
-        },
-        {
-            "id": 2,
-            "account": "支付宝钱包",
-            "type": "income",
-            "category": "工资",
-            "amount": "4200.00",
-            "happened_on": "2026-02-05",
-            "note": "兼职收入",
-        },
-    ],
-    "investment_logs": [
-        {
-            "id": 1,
-            "happened_on": "2026-02-03",
-            "invested": "13000.00",
-            "daily_profit": "7.20",
-            "note": "手动记录",
-        },
-        {
-            "id": 2,
-            "happened_on": "2026-02-04",
-            "invested": "13100.00",
-            "daily_profit": "6.80",
-            "note": "手动记录",
-        },
-    ],
+    "transactions": [],
+    "investment_logs": [],
 }
 
 

--- a/backend/app/api/routes_knowledge.py
+++ b/backend/app/api/routes_knowledge.py
@@ -8,22 +8,7 @@ from app.core.json_store import read_json, write_json
 router = APIRouter(prefix="/knowledge", tags=["knowledge"])
 
 _KNOWLEDGE_FILE = "knowledge.json"
-_DEFAULT_ENTRIES = [
-    {
-        "id": 1,
-        "kind": "entry",
-        "title": "新芯片词条：NPU 架构速记",
-        "markdown": "## 核心点\n- 关注 TOPS/W\n- 关注内存带宽\n- 关注量化支持",
-        "updated_at": "2026-02-07T21:30:00",
-    },
-    {
-        "id": 2,
-        "kind": "blog",
-        "title": "一次接口超时排查记录",
-        "markdown": "## 现象\n请求偶发超时\n\n## 定位\n发现重试参数过小\n\n## 结论\n提高超时并增加日志维度",
-        "updated_at": "2026-02-08T09:10:00",
-    },
-]
+_DEFAULT_ENTRIES: list[dict] = []
 
 
 class EntryCreate(BaseModel):

--- a/backend/app/api/routes_tasks.py
+++ b/backend/app/api/routes_tasks.py
@@ -8,24 +8,7 @@ from app.schemas.tasks import TaskCreate, TaskOut
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 _TASKS_FILE = "tasks.json"
-_DEFAULT_TASKS = [
-    {
-        "id": 1,
-        "title": "理财收益记录",
-        "category": "财产",
-        "importance": "high",
-        "start_at": "2026-02-09T09:00:00",
-        "end_at": "2026-02-09T09:20:00",
-    },
-    {
-        "id": 2,
-        "title": "学习计划",
-        "category": "学习",
-        "importance": "medium",
-        "start_at": "2026-02-09T20:00:00",
-        "end_at": "2026-02-09T21:00:00",
-    },
-]
+_DEFAULT_TASKS: list[dict] = []
 
 
 def _load_tasks() -> list[TaskOut]:

--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -7,6 +7,7 @@ This project currently targets single-machine deployment on your laptop.
 powershell -ExecutionPolicy Bypass -File scripts/init-data.ps1
 ```
 - Creates missing files in `backend/data/` with safe defaults.
+- Fresh installs start with empty records; wallet/investment accounts are pre-created with `0.00` balance.
 
 ## 2) Backup Data
 ```bash

--- a/scripts/init-data.ps1
+++ b/scripts/init-data.ps1
@@ -14,7 +14,23 @@ $defaults = @{
   "feed.json" = @()
   "knowledge.json" = @()
   "assets.json" = @{
-    accounts = @()
+    accounts = @(
+      @{
+        name = "微信钱包"
+        is_cash = $true
+        balance = "0.00"
+      },
+      @{
+        name = "支付宝钱包"
+        is_cash = $true
+        balance = "0.00"
+      },
+      @{
+        name = "支付宝理财"
+        is_cash = $false
+        balance = "0.00"
+      }
+    )
     transactions = @()
     investment_logs = @()
   }


### PR DESCRIPTION
## Summary
Promote empty-default-record behavior updates from dev to main.

## Scope
- tasks/knowledge defaults changed to empty
- assets defaults keep account skeleton with 0.00 balances and empty records
- init-data aligned with runtime defaults
- docs note for fresh-install behavior

## Validation
- PR #14 merged to dev
- branch synced before release PR

Closes #15