### PR TITLE
feat: narrow timeline columns and fix overflow layout

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -126,14 +126,13 @@ a {
 .timeline-grid {
   margin-top: 12px;
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 10px;
+  gap: 8px;
 }
 
 .day-col {
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 10px;
-  padding: 10px;
+  padding: 8px;
   background: rgba(8, 15, 30, 0.65);
   min-height: 220px;
 }
@@ -234,10 +233,6 @@ a {
   .activity-panel {
     grid-column: span 12;
   }
-
-  .timeline-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
 }
 
 .pill[aria-pressed="true"] {
@@ -287,9 +282,21 @@ a {
 
 .timeline-board {
   display: grid;
-  grid-template-columns: 66px 1fr;
+  grid-template-columns: 66px minmax(0, 1fr);
   gap: 10px;
   margin-top: 12px;
+}
+
+.timeline-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-width: 0;
+}
+
+.timeline-scroll .timeline-grid {
+  margin-top: 0;
+  width: max-content;
+  min-width: 100%;
 }
 
 .time-axis {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -291,6 +291,28 @@ a {
   overflow-x: auto;
   overflow-y: hidden;
   min-width: 0;
+  padding-bottom: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(93, 236, 232, 0.55) rgba(7, 13, 24, 0.45);
+}
+
+.timeline-scroll::-webkit-scrollbar {
+  height: 10px;
+}
+
+.timeline-scroll::-webkit-scrollbar-track {
+  background: rgba(7, 13, 24, 0.45);
+  border-radius: 999px;
+}
+
+.timeline-scroll::-webkit-scrollbar-thumb {
+  background: linear-gradient(90deg, rgba(93, 236, 232, 0.7), rgba(103, 242, 161, 0.55));
+  border-radius: 999px;
+  border: 1px solid rgba(93, 236, 232, 0.2);
+}
+
+.timeline-scroll::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(90deg, rgba(93, 236, 232, 0.85), rgba(103, 242, 161, 0.7));
 }
 
 .timeline-scroll .timeline-grid {

--- a/frontend/components/WeeklyTimeline.tsx
+++ b/frontend/components/WeeklyTimeline.tsx
@@ -165,6 +165,7 @@ function blockClassName(block: TimelineBlock): string {
 export function WeeklyTimeline() {
   const [tasks, setTasks] = useState<TaskItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [todayMarker, setTodayMarker] = useState(() => dayKey(new Date()));
 
   useEffect(() => {
     const load = async () => {
@@ -181,7 +182,18 @@ export function WeeklyTimeline() {
     void load();
   }, []);
 
-  const dayWindow = useMemo(() => createDayWindow(), []);
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      const current = dayKey(new Date());
+      setTodayMarker((prev) => (prev === current ? prev : current));
+    }, 60 * 1000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  const dayWindow = useMemo(() => createDayWindow(), [todayMarker]);
   const dayTaskMap = useMemo(() => mapTasksToDayEvents(tasks, dayWindow), [tasks, dayWindow]);
   const hourLabels = useMemo(() => Array.from({ length: 24 }, (_, i) => i), []);
 


### PR DESCRIPTION
## Summary\n- narrow day column minimum width from 140px to 120px\n- tighten timeline grid/day-card spacing for denser layout\n- keep timeline board overflow-safe with horizontal scrolling area\n\n## Notes\n- follows feature -> PR -> dev workflow\n