### PR TITLE
feat(sleep): support post-hoc sleep logs in weekly timeline

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -25,11 +25,13 @@ uv run uvicorn app.main:app --reload
 - `GET/POST /knowledge/`: knowledge entries
 - `GET /knowledge/{id}`: knowledge entry detail
 - `DELETE /knowledge/{id}`: delete entry
+- `GET/POST /sleep/logs`: sleep logs list/create
+- `DELETE /sleep/logs/{id}`: delete sleep log
 - `GET/PUT /settings/`: app settings
 
 ## Persistence
 - Data is persisted as JSON files in `backend/data/`.
-- Current files: `tasks.json`, `feed.json`, `knowledge.json`, `assets.json`, `settings.json`.
+- Current files: `tasks.json`, `feed.json`, `knowledge.json`, `sleep.json`, `assets.json`, `settings.json`.
 
 ## Reference
 - Full API reference: `docs/api-reference.md`

--- a/backend/app/api/routes_sleep.py
+++ b/backend/app/api/routes_sleep.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, HTTPException
+
+from app.core.json_store import read_json, write_json
+from app.schemas.sleep import SleepLogCreate, SleepLogOut
+
+router = APIRouter(prefix="/sleep", tags=["sleep"])
+
+_SLEEP_FILE = "sleep.json"
+_DEFAULT_LOGS: list[dict] = []
+
+
+def _load_logs() -> list[SleepLogOut]:
+    rows = read_json(_SLEEP_FILE, _DEFAULT_LOGS)
+    return [SleepLogOut.model_validate(row) for row in rows]
+
+
+def _save_logs(logs: list[SleepLogOut]) -> None:
+    write_json(_SLEEP_FILE, [item.model_dump(mode="json") for item in logs])
+
+
+@router.get("/logs", response_model=list[SleepLogOut])
+def list_sleep_logs() -> list[SleepLogOut]:
+    logs = _load_logs()
+    return list(sorted(logs, key=lambda row: row.end_at, reverse=True))
+
+
+@router.post("/logs", response_model=SleepLogOut)
+def create_sleep_log(payload: SleepLogCreate) -> SleepLogOut:
+    if payload.end_at <= payload.start_at:
+        raise HTTPException(status_code=400, detail="end_at must be later than start_at")
+
+    logs = _load_logs()
+    next_id = max([item.id for item in logs], default=0) + 1
+    log = SleepLogOut(id=next_id, **payload.model_dump())
+    logs.append(log)
+    _save_logs(logs)
+    return log
+
+
+@router.delete("/logs/{log_id}")
+def delete_sleep_log(log_id: int) -> dict[str, int | bool]:
+    logs = _load_logs()
+    new_logs = [item for item in logs if item.id != log_id]
+    if len(new_logs) == len(logs):
+        raise HTTPException(status_code=404, detail="sleep log not found")
+
+    _save_logs(new_logs)
+    return {"deleted": True, "id": log_id}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from app.api.routes_feed import router as feed_router
 from app.api.routes_health import router as health_router
 from app.api.routes_knowledge import router as knowledge_router
 from app.api.routes_settings import router as settings_router
+from app.api.routes_sleep import router as sleep_router
 from app.api.routes_tasks import router as tasks_router
 from app.core.config import settings
 
@@ -27,6 +28,7 @@ app.include_router(tasks_router)
 app.include_router(feed_router)
 app.include_router(knowledge_router)
 app.include_router(settings_router)
+app.include_router(sleep_router)
 
 
 @app.get("/")

--- a/backend/app/schemas/sleep.py
+++ b/backend/app/schemas/sleep.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class SleepLogCreate(BaseModel):
+    start_at: datetime
+    end_at: datetime
+    note: str | None = None
+
+
+class SleepLogOut(SleepLogCreate):
+    id: int

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -32,6 +32,12 @@ Base URL (local): `http://localhost:8000`
   - Body: `{ "kind": "entry|blog", "title", "markdown" }`
 - `DELETE /knowledge/{entry_id}`
 
+## Sleep
+- `GET /sleep/logs`
+- `POST /sleep/logs`
+  - Body: `{ "start_at", "end_at", "note" }`
+- `DELETE /sleep/logs/{log_id}`
+
 ## Assets
 ### Accounts
 - `GET /assets/accounts`
@@ -65,5 +71,6 @@ Base URL (local): `http://localhost:8000`
   - `backend/data/tasks.json`
   - `backend/data/feed.json`
   - `backend/data/knowledge.json`
+  - `backend/data/sleep.json`
   - `backend/data/assets.json`
   - `backend/data/settings.json`

--- a/frontend/components/WeeklyTimeline.tsx
+++ b/frontend/components/WeeklyTimeline.tsx
@@ -14,7 +14,6 @@ type TimelineBlock = {
   importance?: Importance;
 };
 
-const dayOrder = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"];
 const weekDayMap = ["周日", "周一", "周二", "周三", "周四", "周五", "周六"];
 const WINDOW_DAYS = 7;
 const SLOT_MINUTES = 5;
@@ -226,6 +225,7 @@ export function WeeklyTimeline() {
   const [tasks, setTasks] = useState<TaskItem[]>([]);
   const [sleepLogs, setSleepLogs] = useState<SleepLog[]>([]);
   const [loading, setLoading] = useState(true);
+  const [todayMarker, setTodayMarker] = useState(() => dayKey(new Date()));
 
   useEffect(() => {
     const load = async () => {
@@ -244,7 +244,18 @@ export function WeeklyTimeline() {
     void load();
   }, []);
 
-  const dayWindow = useMemo(() => createDayWindow(), []);
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      const current = dayKey(new Date());
+      setTodayMarker((prev) => (prev === current ? prev : current));
+    }, 60 * 1000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  const dayWindow = useMemo(() => createDayWindow(), [todayMarker]);
   const dayTaskMap = useMemo(() => mapTasksToDayEvents(tasks, dayWindow), [tasks, dayWindow]);
   const daySleepMap = useMemo(() => mapSleepToDayEvents(sleepLogs, dayWindow), [sleepLogs, dayWindow]);
   const dayMergedMap = useMemo(() => mergeDayEvents(dayTaskMap, daySleepMap, dayWindow), [dayTaskMap, daySleepMap, dayWindow]);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -21,6 +21,13 @@ export type TaskItem = {
   end_at: string | null;
 };
 
+export type SleepLog = {
+  id: number;
+  start_at: string;
+  end_at: string;
+  note: string | null;
+};
+
 export type AssetAccount = {
   name: string;
   is_cash: boolean;
@@ -145,6 +152,27 @@ export async function createTask(payload: {
 
 export async function deleteTask(taskId: number): Promise<{ deleted: boolean; id: number }> {
   return apiRequest<{ deleted: boolean; id: number }>(`/tasks/${taskId}`, {
+    method: "DELETE"
+  });
+}
+
+export async function getSleepLogs(): Promise<SleepLog[]> {
+  return apiRequest<SleepLog[]>("/sleep/logs");
+}
+
+export async function createSleepLog(payload: {
+  start_at: string;
+  end_at: string;
+  note?: string;
+}): Promise<SleepLog> {
+  return apiRequest<SleepLog>("/sleep/logs", {
+    method: "POST",
+    body: JSON.stringify(payload)
+  });
+}
+
+export async function deleteSleepLog(logId: number): Promise<{ deleted: boolean; id: number }> {
+  return apiRequest<{ deleted: boolean; id: number }>(`/sleep/logs/${logId}`, {
     method: "DELETE"
   });
 }

--- a/scripts/init-data.ps1
+++ b/scripts/init-data.ps1
@@ -9,10 +9,21 @@ $resolvedDataDir = Join-Path $repoRoot $DataDir
 
 New-Item -ItemType Directory -Force -Path $resolvedDataDir | Out-Null
 
+function Convert-ToStableJson {
+  param($Value)
+
+  if ($Value -is [System.Array] -and $Value.Count -eq 0) {
+    return "[]"
+  }
+
+  return $Value | ConvertTo-Json -Depth 10
+}
+
 $defaults = @{
   "tasks.json" = @()
   "feed.json" = @()
   "knowledge.json" = @()
+  "sleep.json" = @()
   "assets.json" = @{
     accounts = @(
       @{
@@ -45,7 +56,7 @@ $defaults = @{
 foreach ($name in $defaults.Keys) {
   $path = Join-Path $resolvedDataDir $name
   if (-not (Test-Path $path)) {
-    $json = $defaults[$name] | ConvertTo-Json -Depth 10
+    $json = Convert-ToStableJson $defaults[$name]
     Set-Content -Encoding utf8 -Path $path -Value $json
     Write-Output "Initialized: $path"
   }

--- a/scripts/verify-data.ps1
+++ b/scripts/verify-data.ps1
@@ -41,6 +41,7 @@ $required = @(
   "tasks.json",
   "feed.json",
   "knowledge.json",
+  "sleep.json",
   "assets.json",
   "settings.json"
 )
@@ -67,6 +68,14 @@ foreach ($row in $knowledge) {
   Assert-True (Has-Prop $row "id") "knowledge.json entry missing id"
   Assert-True (Has-Prop $row "kind") "knowledge.json entry missing kind"
   Assert-True (Has-Prop $row "markdown") "knowledge.json entry missing markdown"
+}
+
+$sleep = Read-JsonFile (Join-Path $resolvedDataDir "sleep.json")
+Assert-True ($sleep -is [System.Array]) "sleep.json must be an array"
+foreach ($row in $sleep) {
+  Assert-True (Has-Prop $row "id") "sleep.json entry missing id"
+  Assert-True (Has-Prop $row "start_at") "sleep.json entry missing start_at"
+  Assert-True (Has-Prop $row "end_at") "sleep.json entry missing end_at"
 }
 
 $assets = Read-JsonFile (Join-Path $resolvedDataDir "assets.json")


### PR DESCRIPTION
## Summary
Replace fixed sleep blocks with manual sleep log records so users can record actual sleep after waking up.

## Changes
- backend: add sleep log API (GET/POST/DELETE /sleep/logs)
- backend: register sleep router in app main
- scripts: init/verify include sleep.json
- frontend: API client support for sleep logs
- frontend: weekly timeline renders sleep from records (supports cross-day split)
- frontend: tasks page adds sleep log form/list/delete for post-hoc recording
- docs: update API references and backend README

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/init-data.ps1
- powershell -ExecutionPolicy Bypass -File scripts/verify-data.ps1
- uv run python -m compileall app

Closes #17