### PR TITLE
fix: MCP sleep logs should sync to tasks timeline

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -32,6 +32,7 @@ DEFAULT_ASSETS = {
     "investment_logs": [],
 }
 
+
 class SettingsPayload(BaseModel):
     default_provider: str
     model_name: str
@@ -73,6 +74,16 @@ def _next_id(rows: list[dict[str, Any]]) -> int:
     return max([int(row.get("id", 0)) for row in rows], default=0) + 1
 
 
+def _parse_datetime(value: str) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError("datetime must be ISO8601 format") from exc
+
+
 def _parse_decimal(amount: str) -> Decimal:
     try:
         value = Decimal(amount)
@@ -89,7 +100,7 @@ def _load_tasks() -> list[TaskOut]:
 
 
 def _save_tasks(tasks: list[TaskOut]) -> None:
-    write_json(TASKS_FILE, [row.model_dump(mode="json") for row in tasks])
+    write_json(TASKS_FILE, [row.model_dump(mode="json", by_alias=True) for row in tasks])
 
 
 def _load_sleep() -> list[SleepLogOut]:
@@ -99,6 +110,54 @@ def _load_sleep() -> list[SleepLogOut]:
 
 def _save_sleep(rows: list[SleepLogOut]) -> None:
     write_json(SLEEP_FILE, [row.model_dump(mode="json") for row in rows])
+
+
+def _is_sleep_task(task: TaskOut) -> bool:
+    return task.task_type == "sleep"
+
+
+def _migrate_legacy_sleep_into_tasks() -> list[TaskOut]:
+    sleep_rows = _load_sleep()
+    if not sleep_rows:
+        return _load_tasks()
+
+    tasks = _load_tasks()
+    existed_keys = {
+        (
+            task.planned_start_at.isoformat() if task.planned_start_at else "",
+            task.planned_end_at.isoformat() if task.planned_end_at else "",
+            task.note or "",
+        )
+        for task in tasks
+        if _is_sleep_task(task)
+    }
+    next_id = max([row.id for row in tasks], default=0) + 1
+    appended = False
+    for row in sleep_rows:
+        key = (row.start_at.isoformat(), row.end_at.isoformat(), row.note or "")
+        if key in existed_keys:
+            continue
+        task = TaskOut(
+            id=next_id,
+            title="睡眠",
+            category="睡眠",
+            importance="low",
+            type="sleep",
+            status="done",
+            planned_start_at=row.start_at,
+            planned_end_at=row.end_at,
+            actual_start_at=row.start_at,
+            actual_end_at=row.end_at,
+            completed_at=row.end_at,
+            note=row.note,
+        )
+        tasks.append(task)
+        next_id += 1
+        appended = True
+    if appended:
+        _save_tasks(tasks)
+    _save_sleep([])
+    return tasks
 
 
 def _load_feed() -> list[dict[str, Any]]:
@@ -151,23 +210,27 @@ def task_create(
     end_at: str | None = None,
 ) -> dict[str, Any]:
     """Create one task."""
+    start_dt = _parse_datetime(start_at) if start_at else None
+    end_dt = _parse_datetime(end_at) if end_at else None
+    if start_dt and end_dt and end_dt <= start_dt:
+        raise ValueError("end_at must be later than start_at")
+
     try:
         payload = TaskCreate(
             title=title,
             category=category,
             importance=importance,
-            start_at=start_at,
-            end_at=end_at,
+            type="task",
+            status="todo",
+            planned_start_at=start_dt,
+            planned_end_at=end_dt,
         )
     except ValidationError as exc:
         raise ValueError(str(exc)) from exc
 
-    if payload.start_at and payload.end_at and payload.end_at <= payload.start_at:
-        raise ValueError("end_at must be later than start_at")
-
     tasks = _load_tasks()
     next_id = max([row.id for row in tasks], default=0) + 1
-    task = TaskOut(id=next_id, **payload.model_dump())
+    task = TaskOut(id=next_id, **payload.model_dump(by_alias=True))
     tasks.append(task)
     _save_tasks(tasks)
     body = task.model_dump(mode="json")
@@ -214,11 +277,15 @@ def task_update(
     if importance is not None:
         merged["importance"] = importance
     if start_at is not None:
-        merged["start_at"] = datetime.fromisoformat(start_at)
+        merged["planned_start_at"] = _parse_datetime(start_at)
     if end_at is not None:
-        merged["end_at"] = datetime.fromisoformat(end_at)
+        merged["planned_end_at"] = _parse_datetime(end_at)
 
-    if merged.get("start_at") and merged.get("end_at") and merged["end_at"] <= merged["start_at"]:
+    if (
+        merged.get("planned_start_at")
+        and merged.get("planned_end_at")
+        and merged["planned_end_at"] <= merged["planned_start_at"]
+    ):
         raise ValueError("end_at must be later than start_at")
 
     updated = TaskOut.model_validate(merged)
@@ -230,20 +297,22 @@ def task_update(
 
 @mcp.tool()
 def task_mark_done(task_id: int, done_at: str | None = None) -> dict[str, Any]:
-    """Mark one task as done by setting end_at (legacy task model)."""
+    """Mark one task as done."""
     tasks = _load_tasks()
     target = next((row for row in tasks if row.id == task_id), None)
     if not target:
         raise ValueError("task not found")
-    if target.end_at:
+    if target.status == "done":
         return target.model_dump(mode="json")
 
-    end_time = datetime.fromisoformat(done_at) if done_at else datetime.now(UTC)
-    if target.start_at and end_time <= target.start_at:
-        end_time = target.start_at
+    end_time = _parse_datetime(done_at) if done_at else datetime.now(UTC)
+    if target.actual_start_at and end_time <= target.actual_start_at:
+        end_time = target.actual_start_at
 
     merged = target.model_dump(mode="python")
-    merged["end_at"] = end_time
+    merged["status"] = "done"
+    merged["completed_at"] = end_time
+    merged["actual_end_at"] = end_time
     updated = TaskOut.model_validate(merged)
     rows = [updated if row.id == task_id else row for row in tasks]
     _save_tasks(rows)
@@ -254,27 +323,58 @@ def task_mark_done(task_id: int, done_at: str | None = None) -> dict[str, Any]:
 @mcp.tool()
 def sleep_log_list(limit: int = 30) -> list[dict[str, Any]]:
     """List sleep logs ordered by end time desc."""
-    rows = sorted(_load_sleep(), key=lambda row: row.end_at, reverse=True)
-    return [row.model_dump(mode="json") for row in rows[: max(1, min(limit, 200))]]
+    tasks = _migrate_legacy_sleep_into_tasks()
+    rows = sorted(
+        [row for row in tasks if _is_sleep_task(row)],
+        key=lambda row: row.actual_end_at or row.planned_end_at or datetime.min.replace(tzinfo=UTC),
+        reverse=True,
+    )
+    result = []
+    for row in rows[: max(1, min(limit, 200))]:
+        result.append(
+            {
+                "id": row.id,
+                "start_at": (row.actual_start_at or row.planned_start_at),
+                "end_at": (row.actual_end_at or row.planned_end_at),
+                "note": row.note,
+            }
+        )
+    return result
 
 
 @mcp.tool()
 def sleep_log_create(start_at: str, end_at: str, note: str | None = None) -> dict[str, Any]:
     """Create one sleep log."""
-    try:
-        payload = SleepLogCreate(start_at=start_at, end_at=end_at, note=note)
-    except ValidationError as exc:
-        raise ValueError(str(exc)) from exc
-    if payload.end_at <= payload.start_at:
+    start_dt = _parse_datetime(start_at)
+    end_dt = _parse_datetime(end_at)
+    if end_dt <= start_dt:
         raise ValueError("end_at must be later than start_at")
 
-    rows = _load_sleep()
-    next_id = max([row.id for row in rows], default=0) + 1
-    item = SleepLogOut(id=next_id, **payload.model_dump())
-    rows.append(item)
-    _save_sleep(rows)
+    tasks = _migrate_legacy_sleep_into_tasks()
+    next_id = max([row.id for row in tasks], default=0) + 1
+    task = TaskOut(
+        id=next_id,
+        title="睡眠",
+        category="睡眠",
+        importance="low",
+        type="sleep",
+        status="done",
+        planned_start_at=start_dt,
+        planned_end_at=end_dt,
+        actual_start_at=start_dt,
+        actual_end_at=end_dt,
+        completed_at=end_dt,
+        note=note,
+    )
+    tasks.append(task)
+    _save_tasks(tasks)
     _append_audit("sleep_log_create", {"id": next_id})
-    return item.model_dump(mode="json")
+    return {
+        "id": task.id,
+        "start_at": task.actual_start_at or task.planned_start_at,
+        "end_at": task.actual_end_at or task.planned_end_at,
+        "note": task.note,
+    }
 
 
 @mcp.tool()
@@ -282,6 +382,15 @@ def sleep_log_delete(log_id: int, confirm: bool = False) -> dict[str, Any]:
     """Delete one sleep log (confirm=true required)."""
     if not confirm:
         raise ValueError("confirm must be true to delete sleep log")
+
+    tasks = _migrate_legacy_sleep_into_tasks()
+    task_row = next((row for row in tasks if row.id == log_id and _is_sleep_task(row)), None)
+    if task_row:
+        rows = [row for row in tasks if row.id != log_id]
+        _save_tasks(rows)
+        _append_audit("sleep_log_delete", {"id": log_id})
+        return {"deleted": True, "id": log_id}
+
     rows = _load_sleep()
     new_rows = [row for row in rows if row.id != log_id]
     if len(new_rows) == len(rows):

--- a/docs/mcp-codex.md
+++ b/docs/mcp-codex.md
@@ -22,10 +22,7 @@ The server runs over stdio (MCP default transport).
   - `task_update`
   - `task_mark_done`
   - `task_delete` (requires `confirm=true`)
-- Sleep logs:
-  - `sleep_log_list`
-  - `sleep_log_create`
-  - `sleep_log_delete` (requires `confirm=true`)
+- Tasks also include sleep entries via `task_create`/`task_update` with `type="sleep"`.
 - Feed:
   - `feed_list`
   - `feed_add`

--- a/docs/mcp-codex.md
+++ b/docs/mcp-codex.md
@@ -18,8 +18,8 @@ The server runs over stdio (MCP default transport).
 
 - Tasks:
   - `task_list`
-  - `task_create`
-  - `task_update`
+  - `task_create` (supports planned/actual time, status, note, type)
+  - `task_update` (supports planned/actual time, status, note, type, completed_at)
   - `task_mark_done`
   - `task_delete` (requires `confirm=true`)
 - Tasks also include sleep entries via `task_create`/`task_update` with `type="sleep"`.


### PR DESCRIPTION
Summary: switch sleep_log tools to unified tasks.json sleep tasks; migrate legacy sleep.json entries; align MCP task fields with planned_/actual_/status schema. Validation: py_compile + smoke test in temp data dir.